### PR TITLE
Typo: Planesalker -> Planeswalker

### DIFF
--- a/css/mana.css
+++ b/css/mana.css
@@ -411,7 +411,7 @@
   left: 1.0em;
 }
 /**
- * Planesalker symbols */
+ * Planeswalker symbols */
 .ms-loyalty-up,
 .ms-loyalty-down,
 .ms-loyalty-zero,

--- a/less/loyalty.less
+++ b/less/loyalty.less
@@ -1,5 +1,5 @@
 /**
- * Planesalker symbols */
+ * Planeswalker symbols */
 
 .@{ms-prefix}-loyalty {
 


### PR DESCRIPTION
Found a silly typo in a couple of places.