### PR TITLE
Fix mismatched symbols

### DIFF
--- a/cheatsheet.html
+++ b/cheatsheet.html
@@ -89,10 +89,9 @@
                     <span class="utf"><i>&#xe61a;</i> ms-tap <code>&amp;#xe61a;</code></span>
                     <span class="utf"><i>&#xe61b;</i> ms-untap <code>&amp;#xe61b;</code></span>
                     <span class="utf"><i>&#xe61c;</i> ms-tap-alt <code>&amp;#xe61c;</code></span>
-                    <span class="utf"><i>&#xe616;</i> ms-chaos <code>&amp;#xe616;</code></span>
-                    <span class="utf"><i>&#xe61d;</i> ms-1-2 <code>&amp;#xe61d;</code></span>
-                    <span class="utf"><i>&#xe902;</i> ms-infinity <code>&amp;#xe902;</code></span>
-                    <span class="utf"><i>&#xe903;</i> ms-s <code>&amp;#xe903;</code></span>
+                    <span class="utf"><i>&#xe61d;</i> ms-chaos <code>&amp;#xe61d;</code></span>
+                    <span class="utf"><i>&#xe902;</i> ms-1-2 <code>&amp;#xe902;</code></span>
+                    <span class="utf"><i>&#xe903;</i> ms-infinity <code>&amp;#xe903;</code></span>
                     <div class="clear"></div>
                 </div>
                 <div class="vectors">


### PR DESCRIPTION
On the cheetsheet, the chaos, half, and infinity symbols are offset by 1. There is also an extra snow mana.