### PR TITLE
Fix link and typo in Dual-Layered Symbols

### DIFF
--- a/attributes.html
+++ b/attributes.html
@@ -202,7 +202,7 @@
                     <span class="each"><i class="ms ms-2x ms-multicolor ms-duo ms-duo-color ms-grad"></i> Two with color</span>
                 </div>
                 <div class="explanation">
-                    <p>The [multicolor symbol](https://mtg.gamepedia.com/Multicolored) has 2 layers and the only wayh to reliably achieve this is with 2 glyphs. Add <code>.ms-duo</code> and <code>.ms-multicolor</code> will add the background layer and knock out the foreground. If you add <code>.ms-duo-color</code> and optionally <code>.ms-grad</code> it will colorize it like the official symbol.</p>
+                    <p>The <a href="https://mtg.gamepedia.com/Multicolored">multicolor symbol</a> has 2 layers and the only way to reliably achieve this is with 2 glyphs. Add <code>.ms-duo</code> and <code>.ms-multicolor</code> will add the background layer and knock out the foreground. If you add <code>.ms-duo-color</code> and optionally <code>.ms-grad</code> it will colorize it like the official symbol.</p>
                     <blockquote>
                         &lt;<span class="e">i</span> <span class="a">class</span>=<span class="v">"ms ms-multicolor"</span>&gt;&lt;/<span class="e">i</span>&gt; One layer<br />
                         &lt;<span class="e">i</span> <span class="a">class</span>=<span class="v">"ms ms-multicolor ms-duo"</span>&gt;&lt;/<span class="e">i</span>&gt; Two layers<br />


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/403456/119258484-0cf36e00-bbca-11eb-9a59-5e1d2c9f2fe9.png)

After:
![image](https://user-images.githubusercontent.com/403456/119258509-34e2d180-bbca-11eb-83b2-9df5a55f4ed5.png)
