### PR TITLE
Escape apostrophes in scss variables

### DIFF
--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -3,7 +3,7 @@ $ms-font-path: '../fonts' !default;
 $ms-version: '1.14.0' !default;
 $ms-font-size-base: 14px !default;
 $ms-prefix: ms !default;
-$ms-serif-font: 'MPlantin, Garamond, Palatino, 'Times New Roman', Times, serif' !default;
+$ms-serif-font: 'MPlantin, Garamond, Palatino, \'Times New Roman\', Times, serif' !default;
 
 // mana colors
 $ms-border-black: #010101;


### PR DESCRIPTION
the apostrophes in the ms-serif-font variable generates an invalid attribute
This breaks the loyalty symbols